### PR TITLE
fix(material-ui): ensure password type is set on the password field

### DIFF
--- a/packages/amplify-material-ui/src/auth/sign-up.tsx
+++ b/packages/amplify-material-ui/src/auth/sign-up.tsx
@@ -30,6 +30,7 @@ const signUpFields = [
     key: 'username',
     required: true,
     placeholder: 'Username',
+    type: 'text',
     displayOrder: 1,
   },
   {
@@ -100,6 +101,7 @@ export const SignUp: React.FC<SignUpProps> = (props) => {
                   key={field.key}
                   name={field.key}
                   label={field.label}
+                  type={field.type}
                   component={TextField}
                 />
               ))}

--- a/packages/amplify-material-ui/test/auth/__snapshots__/sign-up.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/sign-up.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`sign-up should be rendered correctly 1`] = `
                 class="MuiInputBase-input MuiOutlinedInput-input"
                 name="password"
                 required=""
-                type="text"
+                type="password"
                 value=""
               />
               <fieldset
@@ -141,7 +141,7 @@ exports[`sign-up should be rendered correctly 1`] = `
                 class="MuiInputBase-input MuiOutlinedInput-input"
                 name="email"
                 required=""
-                type="text"
+                type="email"
                 value=""
               />
               <fieldset


### PR DESCRIPTION
The password field on the sign up form currently doesn't have a type defined so it appears as text.