### PR TITLE
Customise sign up fields

### DIFF
--- a/packages/amplify-auth-hooks/src/use-sign-up.tsx
+++ b/packages/amplify-auth-hooks/src/use-sign-up.tsx
@@ -10,7 +10,8 @@ const logger = new Logger('useSignUp');
 export const useSignUp = (): ((
   username: string,
   password: string,
-  validationData?: Record<string, string>
+  validationData?: Record<string, string>,
+  attributes?: Record<string, string>
 ) => Promise<void>) => {
   invariant(
     Auth && typeof Auth.signUp === 'function',
@@ -20,11 +21,10 @@ export const useSignUp = (): ((
   const { handleStateChange } = useAuthContext();
 
   return async (
-    email: string,
+    username: string,
     password: string,
-    validationData?: {
-      [key: string]: string;
-    }
+    validationData?: Record<string, string>,
+    attributes?: Record<string, string>
   ): Promise<void> => {
     const validationDataArray: CognitoUserAttribute[] = [];
 
@@ -40,15 +40,15 @@ export const useSignUp = (): ((
     }
 
     const signupInfo = {
-      username: email,
-      password: password,
-      attributes: {},
+      username,
+      password,
+      attributes,
       validationData: validationDataArray,
     };
 
     try {
       const data = await Auth.signUp(signupInfo);
-      handleStateChange('confirmSignUp', data.user.getUsername());
+      handleStateChange('confirmSignUp', { username: data.user.getUsername() });
     } catch (error) {
       logger.error(error);
       throw error;

--- a/packages/amplify-material-ui/README.md
+++ b/packages/amplify-material-ui/README.md
@@ -79,6 +79,96 @@ withAuthenticator(App, {
 });
 ```
 
+
+## Localization
+
+amplify-material-ui is built with [react-intl](https://formatjs.io/docs/getting-started/installation/) support. You can add your own localized strings translations by passing the intlProps into the authenticator.
+
+```typescript
+withAuthenticator(App, {
+  intlProps: {
+    customMessages: {
+      de: {
+        global: {
+          labels: {
+            username: 'Overwrite username label',
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+
+## Customize sign-up form
+
+You can customize the sign-up fields as well as the initial values passed into the form:
+
+```typescript
+const signUpConfig = {
+  signUpFields: [
+    {
+      label: 'First name',
+      key: 'given_name',
+      required: true,
+      displayOrder: 1,
+      type: 'text',
+      intl: {
+        label: 'signUp.labels.family_name',
+      }
+    },
+    {
+      label: 'Surname',
+      key: 'family_name',
+      required: true,
+      displayOrder: 2,
+      type: 'text',
+      intl: {
+        label: 'signUp.labels.given_name',
+      }
+    },
+    {
+      label: 'Email',
+      key: 'email',
+      required: true,
+      displayOrder: 3,
+      type: 'email',
+    },
+    {
+      label: 'Password',
+      key: 'password',
+      required: true,
+      displayOrder: 4,
+      type: 'password',
+    },
+  ],
+  initialValues: {
+    given_name: 'John',
+    family_name: 'Smith',
+  },
+};
+
+withAuthenticator(App, {
+  signUpConfig,
+  intlProps: {
+    customMessages: {
+      de: {
+        signUp: {
+          labels: {
+            given_name: 'Translated given name',
+            family_name: 'Translated family name',
+          },
+        },
+      },
+    },
+  },
+});
+
+```
+
+## Customize sign-up fields
+
 ## License
 
 [MIT](LICENSE)

--- a/packages/amplify-material-ui/src/auth/authenticator.tsx
+++ b/packages/amplify-material-ui/src/auth/authenticator.tsx
@@ -8,12 +8,14 @@ import {
 import { ThemeProvider, ThemeProviderProps } from '../ui';
 import { AuthRoute } from './auth-route';
 import { AuthRouter, AuthRouterProps } from './auth-router';
+import { SignUpConfig } from './sign-up';
 
 export interface AuthenticatorProps
   extends AuthRouterProps,
     ThemeProviderProps {
   intlProps?: IntlProviderProps;
   notificationProps?: NotificationProviderProps;
+  signUpConfig?: SignUpConfig;
 }
 
 export const Authenticator: React.FC<AuthenticatorProps> = (props) => {

--- a/packages/amplify-material-ui/test/auth/__snapshots__/sign-up.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/sign-up.test.tsx.snap
@@ -1,5 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`sign-up should allow custom initial values 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXs"
+  >
+    <div
+      class="MuiPaper-root makeStyles-paper-45 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiBox-root MuiBox-root-48 makeStyles-box-46"
+      >
+        <div
+          class="MuiAvatar-root MuiAvatar-circle makeStyles-avatar-47 MuiAvatar-colorDefault"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM9 6c0-1.66 1.34-3 3-3s3 1.34 3 3v2H9V6zm9 14H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+            />
+          </svg>
+        </div>
+        <h1
+          class="MuiTypography-root MuiTypography-h6"
+        >
+          Create a new account
+        </h1>
+      </div>
+      <form
+        action="#"
+        class="makeStyles-form-43"
+      >
+        <div
+          class="MuiBox-root MuiBox-root-50 makeStyles-box-49"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-required Mui-required"
+              data-shrink="true"
+            >
+              Username
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="username"
+                required=""
+                type="text"
+                value="username initial value"
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-51 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-53 PrivateNotchedOutline-legendNotched-54"
+                >
+                  <span>
+                    Username *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-required Mui-required"
+              data-shrink="true"
+            >
+              Password
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="password"
+                required=""
+                type="password"
+                value="extremelysecurepassword1!"
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-51 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-53 PrivateNotchedOutline-legendNotched-54"
+                >
+                  <span>
+                    Password *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-required Mui-required"
+              data-shrink="true"
+            >
+              Email
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="email"
+                required=""
+                type="email"
+                value="email@example.com"
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-51 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-53 PrivateNotchedOutline-legendNotched-54"
+                >
+                  <span>
+                    Email *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root MuiBox-root-56 makeStyles-box-55"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-submit-44 MuiButton-containedPrimary MuiButton-fullWidth"
+            tabindex="0"
+            type="submit"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Create Account
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiGrid-root MuiGrid-container"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            >
+              Have an account? 
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-body2 MuiTypography-colorPrimary"
+                href="#"
+              >
+                Sign in
+              </a>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`sign-up should be rendered correctly 1`] = `
 <DocumentFragment>
   <div
@@ -164,6 +362,482 @@ exports[`sign-up should be rendered correctly 1`] = `
         >
           <button
             class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-submit-2 MuiButton-containedPrimary MuiButton-fullWidth"
+            tabindex="0"
+            type="submit"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Create Account
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiGrid-root MuiGrid-container"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            >
+              Have an account? 
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-body2 MuiTypography-colorPrimary"
+                href="#"
+              >
+                Sign in
+              </a>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`sign-up should render custom sign-up fields 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXs"
+  >
+    <div
+      class="MuiPaper-root makeStyles-paper-17 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiBox-root MuiBox-root-20 makeStyles-box-18"
+      >
+        <div
+          class="MuiAvatar-root MuiAvatar-circle makeStyles-avatar-19 MuiAvatar-colorDefault"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM9 6c0-1.66 1.34-3 3-3s3 1.34 3 3v2H9V6zm9 14H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+            />
+          </svg>
+        </div>
+        <h1
+          class="MuiTypography-root MuiTypography-h6"
+        >
+          Create a new account
+        </h1>
+      </div>
+      <form
+        action="#"
+        class="makeStyles-form-15"
+      >
+        <div
+          class="MuiBox-root MuiBox-root-22 makeStyles-box-21"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              First name
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="given_name"
+                required=""
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-23 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-25"
+                >
+                  <span>
+                    First name *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              Surname
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="family_name"
+                required=""
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-23 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-25"
+                >
+                  <span>
+                    Surname *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              Email
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="email"
+                required=""
+                type="email"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-23 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-25"
+                >
+                  <span>
+                    Email *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              Password
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="password"
+                required=""
+                type="password"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-23 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-25"
+                >
+                  <span>
+                    Password *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root MuiBox-root-28 makeStyles-box-27"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-submit-16 MuiButton-containedPrimary MuiButton-fullWidth"
+            tabindex="0"
+            type="submit"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Create Account
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiGrid-root MuiGrid-container"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            >
+              Have an account? 
+              <a
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-body2 MuiTypography-colorPrimary"
+                href="#"
+              >
+                Sign in
+              </a>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`sign-up should render custom sign-up fields in the correct order 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXs"
+  >
+    <div
+      class="MuiPaper-root makeStyles-paper-31 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiBox-root MuiBox-root-34 makeStyles-box-32"
+      >
+        <div
+          class="MuiAvatar-root MuiAvatar-circle makeStyles-avatar-33 MuiAvatar-colorDefault"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM9 6c0-1.66 1.34-3 3-3s3 1.34 3 3v2H9V6zm9 14H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+            />
+          </svg>
+        </div>
+        <h1
+          class="MuiTypography-root MuiTypography-h6"
+        >
+          Create a new account
+        </h1>
+      </div>
+      <form
+        action="#"
+        class="makeStyles-form-29"
+      >
+        <div
+          class="MuiBox-root MuiBox-root-36 makeStyles-box-35"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              First name
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="given_name"
+                required=""
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-37 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-39"
+                >
+                  <span>
+                    First name *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              Surname
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="family_name"
+                required=""
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-37 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-39"
+                >
+                  <span>
+                    Surname *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              Email
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="email"
+                required=""
+                type="email"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-37 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-39"
+                >
+                  <span>
+                    Email *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
+            >
+              Password
+              <span
+                aria-hidden="true"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+              >
+                 *
+              </span>
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input"
+                name="password"
+                required=""
+                type="password"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-37 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-39"
+                >
+                  <span>
+                    Password *
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root MuiBox-root-42 makeStyles-box-41"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-submit-30 MuiButton-containedPrimary MuiButton-fullWidth"
             tabindex="0"
             type="submit"
           >

--- a/packages/amplify-material-ui/test/auth/sign-up.test.tsx
+++ b/packages/amplify-material-ui/test/auth/sign-up.test.tsx
@@ -9,4 +9,99 @@ describe('sign-up', () => {
     const { asFragment } = render(withContext(<SignUp />)());
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('should render custom sign-up fields', () => {
+    const signUpConfig = {
+      signUpFields: [
+        {
+          label: 'First name',
+          key: 'given_name',
+          required: true,
+          displayOrder: 1,
+          type: 'text',
+        },
+        {
+          label: 'Surname',
+          key: 'family_name',
+          required: true,
+          displayOrder: 2,
+          type: 'text',
+        },
+        {
+          label: 'Email',
+          key: 'email',
+          required: true,
+          displayOrder: 3,
+          type: 'email',
+        },
+        {
+          label: 'Password',
+          key: 'password',
+          required: true,
+          displayOrder: 4,
+          type: 'password',
+        },
+      ],
+    };
+
+    const { asFragment } = render(
+      withContext(<SignUp signUpConfig={signUpConfig} />)()
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render custom sign-up fields in the correct order', () => {
+    const signUpConfig = {
+      signUpFields: [
+        {
+          label: 'Password',
+          key: 'password',
+          required: true,
+          displayOrder: 4,
+          type: 'password',
+        },
+        {
+          label: 'Email',
+          key: 'email',
+          required: true,
+          displayOrder: 3,
+          type: 'email',
+        },
+        {
+          label: 'Surname',
+          key: 'family_name',
+          required: true,
+          displayOrder: 2,
+          type: 'text',
+        },
+        {
+          label: 'First name',
+          key: 'given_name',
+          required: true,
+          displayOrder: 1,
+          type: 'text',
+        },
+      ],
+    };
+
+    const { asFragment } = render(
+      withContext(<SignUp signUpConfig={signUpConfig} />)()
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should allow custom initial values', () => {
+    const signUpConfig = {
+      initialValues: {
+        username: 'username initial value',
+        email: 'email@example.com',
+        password: 'extremelysecurepassword1!',
+      },
+    };
+
+    const { asFragment } = render(
+      withContext(<SignUp signUpConfig={signUpConfig} />)()
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Customise Signup Fields

This PR aims to add the ability to customise the sign up form fields similar to the react-amplify authenticator component.

- [Amplify JS API](https://aws-amplify.github.io/amplify-js/api/interfaces/iauthenticatorprops.html)
- [Amplify Usage](https://docs.amplify.aws/ui/auth/authenticator/q/framework/react#custom-form-fields)

## Current Problem

I couldn't get the sign up form working with the following cognito settings:

![image](https://user-images.githubusercontent.com/881537/96675693-f680fc00-13c7-11eb-9e21-135266c2e72d.png)

The reason being is my username fields is the same as my email field. The current sign up form displays two separate fields. The react component library allows you to customise the fields as linked above.


## New Usage Example
I'm pushing this early to get some feedback on the approach.

```
const signUpConfig = {
  signUpFields: [
    {
      label: 'First name',
      key: 'given_name',
      required: true,
      displayOrder: 1,
      type: 'text',
    },
    {
      label: 'Surname',
      key: 'family_name',
      required: true,
      displayOrder: 2,
      type: 'text',
    },
    {
      label: 'Email',
      key: 'email',
      required: true,
      displayOrder: 3,
      type: 'email',
    },
    {
      label: 'Password',
      key: 'password',
      required: true,
      displayOrder: 4,
      type: 'password',
    },
  ],
};

export default withAuthenticator(Dashboard, {
  usernameAttribute: UsernameAttribute.EMAIL,
  signUpConfig
});
```

## Feedback

This should work as is but probably needs a cleanup (it depends on #18). I've pushed early so that I can get some feedback so that would be much appreciated. If there's a better way to do things let me know.