### PR TITLE
Add uninitialized state

### DIFF
--- a/packages/amplify-auth-hooks/src/use-auth.tsx
+++ b/packages/amplify-auth-hooks/src/use-auth.tsx
@@ -11,6 +11,8 @@ export interface AuthProps {
   onStateChange?: (prevState: AuthState, newState: AuthState) => AuthState;
 }
 
+const UNINITIALIZED = 'uninitialized';
+
 export const useAuth = (props: AuthProps): AuthContextProps => {
   invariant(
     Auth && typeof Auth.currentAuthenticatedUser === 'function',
@@ -20,7 +22,7 @@ export const useAuth = (props: AuthProps): AuthContextProps => {
   const { initialAuthState = 'signIn', onStateChange } = props;
 
   const [state, setState] = React.useState<AuthState>({
-    authState: initialAuthState,
+    authState: UNINITIALIZED,
     authData: null,
   });
 


### PR DESCRIPTION
It's currently impossible to tell if we haven't yet queried Amplify to see if we have a current user. This allows us to check for that and wait to render some UI if we aren't yet initialized. 