### PR TITLE
Update the peer dependency on "@aws-amplify/core"

### DIFF
--- a/packages/amplify-material-ui/package.json
+++ b/packages/amplify-material-ui/package.json
@@ -42,7 +42,7 @@
     "yup": "^0.32.9"
   },
   "peerDependencies": {
-    "@aws-amplify/core": "^1.0.27",
+    "@aws-amplify/core": "^4.3.10",
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.7",
     "react": ">=17"


### PR DESCRIPTION
Due to the caret notation, the peer dependency on "@aws-amplify/core" was limited to version 1.

This precluded any dev installation of this package, because the dev installation required both versions 4 (as a dev dependency) and version 1 (as a peer dependency), which is an unresolvable conflict.

This commit brings the peer dependency on "@aws-amplify/core" to match its dev dependency version, just like other peer dependencies.