### PR TITLE
Elevate "@mui/styles" to production dependency

### DIFF
--- a/packages/amplify-material-ui/package.json
+++ b/packages/amplify-material-ui/package.json
@@ -30,6 +30,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@mui/styles": "^5.4.1",
     "amplify-auth-hooks": "^1.0.0",
     "clsx": "^1.1.1",
     "formik": "^2.2.9",
@@ -53,7 +54,6 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.7",
-    "@mui/styles": "^5.4.1",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",


### PR DESCRIPTION
Many files in the build result contain the following imports:

```
import makeStyles from '@mui/styles/makeStyles';
import createStyles from '@mui/styles/createStyles';
```

With `@mui/styles` being declared a dev-level dependency, these imports cannot be resolved by consumers that do not install `@mui/styles`.
