### PR TITLE
Convert jss to tss-react

### DIFF
--- a/packages/amplify-material-ui/README.md
+++ b/packages/amplify-material-ui/README.md
@@ -6,10 +6,10 @@
 
 ```sh
 // with npm
-npm install amplify-material-ui
+npm install amplify-material-ui @mui/material @emotion/react @emotion/styled
 
 // with yarn
-yarn add amplify-material-ui
+yarn add amplify-material-ui @mui/material @emotion/react @emotion/styled
 ```
 
 ## How to use
@@ -168,6 +168,31 @@ withAuthenticator(App, {
 ```
 
 ## Customize sign-up fields
+
+## Enable SSR
+
+To enable SSR you have to explicitly provide an emotion cache to MUI:
+
+```typescript
+import { render } from "react-dom";
+import { CacheProvider } from "@emotion/react";
+import createCache from "@emotion/cache";
+
+export const muiCache = createCache({
+    "key": "mui",
+    "prepend": true
+});
+
+//NOTE: Don't use <StyledEngineProvider injectFirst/>
+render(
+    <CacheProvider value={muiCache}>
+        {/* ...your app...*/}
+    </CacheProvider>,
+    document.getElementById("root")
+);
+```
+
+Also follow [TSS's instructions to enable SSR](https://docs.tss-react.dev/ssr)
 
 ## License
 

--- a/packages/amplify-material-ui/package.json
+++ b/packages/amplify-material-ui/package.json
@@ -40,10 +40,12 @@
     "react-intl": "^5.23.0",
     "react-recaptcha-hook": "^1.2.2",
     "tiny-invariant": "^1.2.0",
+    "tss-react": "^3.7.0",
     "yup": "^0.32.9"
   },
   "peerDependencies": {
     "@aws-amplify/core": "^4.3.10",
+    "@emotion/react": "^11.4.1",
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.7",
     "react": ">=17"

--- a/packages/amplify-material-ui/src/auth/confirm-sign-in.tsx
+++ b/packages/amplify-material-ui/src/auth/confirm-sign-in.tsx
@@ -3,8 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { useConfirmSignIn } from 'amplify-auth-hooks';
 import { Button, Grid } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 
@@ -12,8 +11,8 @@ import { FormSection, SectionHeader, SectionBody, SectionFooter } from '../ui';
 import { useNotificationContext } from '../notification';
 import { ChangeAuthStateLink } from './change-auth-state-link';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -21,11 +20,10 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export const ConfirmSignIn: React.FC = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const { confirm, mfaType } = useConfirmSignIn();

--- a/packages/amplify-material-ui/src/auth/confirm-sign-up.tsx
+++ b/packages/amplify-material-ui/src/auth/confirm-sign-up.tsx
@@ -3,8 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { useConfirmSignUp } from 'amplify-auth-hooks';
 import { Button, Grid, Link } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 
@@ -12,8 +11,8 @@ import { FormSection, SectionHeader, SectionBody, SectionFooter } from '../ui';
 import { useNotificationContext } from '../notification';
 import { ChangeAuthStateLink } from './change-auth-state-link';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -21,11 +20,10 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export const ConfirmSignUp: React.FC = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const { confirm, resend } = useConfirmSignUp();

--- a/packages/amplify-material-ui/src/auth/forgot-password.tsx
+++ b/packages/amplify-material-ui/src/auth/forgot-password.tsx
@@ -3,8 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { useForgotPassword } from 'amplify-auth-hooks';
 import { Button, Grid, Link } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 
@@ -13,8 +12,8 @@ import { useNotificationContext } from '../notification';
 import { useUsernameField } from './use-username-field';
 import { ChangeAuthStateLink } from './change-auth-state-link';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -22,11 +21,10 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export const ForgotPassword: React.FC = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const { delivery, submit, send, username } = useForgotPassword();

--- a/packages/amplify-material-ui/src/auth/greetings.tsx
+++ b/packages/amplify-material-ui/src/auth/greetings.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useAuthContext, useSignOut } from 'amplify-auth-hooks';
-import clsx from 'clsx';
 import { AppBar, Toolbar, IconButton, Typography, Menu, MenuItem, Divider } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 
 import { UsernameAttribute } from './types';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     toolbar: {
       paddingRight: 24,
     },
@@ -25,8 +23,7 @@ const useStyles = makeStyles((theme: Theme) =>
         duration: theme.transitions.duration.leavingScreen,
       }),
     },
-  }),
-);
+  }));
 
 export interface GreetingsProps {
   renderUserMenu?: () => React.ReactElement;
@@ -53,7 +50,7 @@ export const Greetings: React.FC<GreetingsProps> = (props) => {
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
     setAnchorEl(event.currentTarget);
@@ -81,7 +78,7 @@ export const Greetings: React.FC<GreetingsProps> = (props) => {
   };
 
   return (
-    <AppBar position="absolute" className={clsx(classes.appBar, className)}>
+    <AppBar position="absolute" className={cx(classes.appBar, className)}>
       <Toolbar className={classes.toolbar}>
         {burgerMenu}
         {typeof title === 'string' ? (

--- a/packages/amplify-material-ui/src/auth/loading.tsx
+++ b/packages/amplify-material-ui/src/auth/loading.tsx
@@ -2,25 +2,23 @@ import * as React from 'react';
 import { CircularProgress } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 
 import { FormSection } from '../ui';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     progress: {
       margin: theme.spacing(2),
     },
-  }),
-);
+  }));
 
 export interface LoadingProps {
   color?: 'inherit' | 'primary' | 'secondary' | undefined;
 }
 
 export const Loading: React.FC<LoadingProps> = ({ color }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <FormSection>

--- a/packages/amplify-material-ui/src/auth/require-new-password.tsx
+++ b/packages/amplify-material-ui/src/auth/require-new-password.tsx
@@ -3,8 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { useRequireNewPassword } from 'amplify-auth-hooks';
 import { Button, Grid } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 import * as Yup from 'yup';
@@ -13,8 +12,8 @@ import { FormSection, SectionHeader, SectionBody, SectionFooter } from '../ui';
 import { useNotificationContext } from '../notification';
 import { ChangeAuthStateLink } from './change-auth-state-link';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -22,11 +21,10 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export const RequireNewPassword: React.FC = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const completeNewPassword = useRequireNewPassword();

--- a/packages/amplify-material-ui/src/auth/sign-in.tsx
+++ b/packages/amplify-material-ui/src/auth/sign-in.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { Button, Grid } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 import { useSignIn } from 'amplify-auth-hooks';
@@ -14,8 +13,8 @@ import { useUsernameField } from './use-username-field';
 import { ChangeAuthStateLink } from './change-auth-state-link';
 import { UsernameAttribute } from './types';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -23,8 +22,7 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export interface SignInProps {
   validationData?: { [key: string]: string };
@@ -36,7 +34,7 @@ export interface SignInProps {
 export const SignIn: React.FC<SignInProps> = (props) => {
   const { validationData, hideSignUpLink = false, hideForgotPasswordLink = false, usernameAttribute } = props;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const signIn = useSignIn();

--- a/packages/amplify-material-ui/src/auth/sign-up.tsx
+++ b/packages/amplify-material-ui/src/auth/sign-up.tsx
@@ -3,8 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { useSignUp } from 'amplify-auth-hooks';
 import { Button, Grid } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 
@@ -13,8 +12,8 @@ import { useNotificationContext } from '../notification';
 import { ChangeAuthStateLink } from './change-auth-state-link';
 import { UsernameAttribute } from './types';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -22,8 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export type SignUpValues = Record<string, string>;
 
@@ -100,7 +98,7 @@ export const SignUp: React.FC<SignUpProps> = (props) => {
   const initialValues = signUpConfig?.initialValues ?? {};
   signUpFields.forEach((field) => (initialValues[field.key] = initialValues[field.key] ?? ''));
 
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const signUp = useSignUp();

--- a/packages/amplify-material-ui/src/auth/totp-setup.tsx
+++ b/packages/amplify-material-ui/src/auth/totp-setup.tsx
@@ -3,8 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { useTOTPSetup } from 'amplify-auth-hooks';
 import { Button } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-mui';
 import QRCode from 'qrcode.react';
@@ -13,8 +12,8 @@ import { FormSection, SectionHeader, SectionBody, SectionFooter } from '../ui';
 import { useNotificationContext } from '../notification';
 import { Loading } from './loading';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -22,11 +21,10 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export const TOTPSetup: React.FC = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const { code, verifyTotpToken } = useTOTPSetup();

--- a/packages/amplify-material-ui/src/auth/verify-contact.tsx
+++ b/packages/amplify-material-ui/src/auth/verify-contact.tsx
@@ -4,8 +4,7 @@ import { useAuthContext, useVerifyContact } from 'amplify-auth-hooks';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { Button, Grid, FormControlLabel, Radio } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 import { Formik, Field, Form } from 'formik';
 import { RadioGroup, TextField } from 'formik-mui';
 
@@ -15,8 +14,8 @@ import { ChangeAuthStateLink } from './change-auth-state-link';
 
 const logger = new Logger('VerifyContact');
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     form: {
       width: '100%', // Fix IE 11 issue.
       marginTop: theme.spacing(1),
@@ -24,11 +23,10 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(3, 0, 2),
     },
-  }),
-);
+  }));
 
 export const VerifyContact: React.FC = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { formatMessage } = useIntl();
   const { showNotification } = useNotificationContext();
   const { authData } = useAuthContext();

--- a/packages/amplify-material-ui/src/ui/form-section.tsx
+++ b/packages/amplify-material-ui/src/ui/form-section.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { Paper } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 
 import { FormContainer } from './form-container';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     paper: {
       marginTop: theme.spacing(12),
       display: 'flex',
@@ -17,11 +16,10 @@ const useStyles = makeStyles((theme: Theme) =>
       minWidth: '300px',
       padding: theme.spacing(1),
     },
-  }),
-);
+  }));
 
 export const FormSection: React.FC = ({ children }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <FormContainer>

--- a/packages/amplify-material-ui/src/ui/section-body.tsx
+++ b/packages/amplify-material-ui/src/ui/section-body.tsx
@@ -2,17 +2,15 @@ import * as React from 'react';
 import { Box } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((_theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((_theme: Theme) =>
+  ({
     box: {},
-  }),
-);
+  }));
 
 export const SectionBody: React.FC = ({ children }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return <Box className={classes.box}>{children}</Box>;
 };

--- a/packages/amplify-material-ui/src/ui/section-footer.tsx
+++ b/packages/amplify-material-ui/src/ui/section-footer.tsx
@@ -2,17 +2,15 @@ import * as React from 'react';
 import { Box } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((_theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((_theme: Theme) =>
+  ({
     box: {},
-  }),
-);
+  }));
 
 export const SectionFooter: React.FC = ({ children }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return <Box className={classes.box}>{children}</Box>;
 };

--- a/packages/amplify-material-ui/src/ui/section-header.tsx
+++ b/packages/amplify-material-ui/src/ui/section-header.tsx
@@ -3,11 +3,10 @@ import { Avatar, Box, Typography } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { Theme } from '@mui/material/styles';
 
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
+const useStyles = makeStyles()((theme: Theme) =>
+  ({
     box: {
       marginTop: theme.spacing(1),
       display: 'flex',
@@ -18,11 +17,10 @@ const useStyles = makeStyles((theme: Theme) =>
       margin: theme.spacing(1),
       backgroundColor: theme.palette.secondary.main,
     },
-  }),
-);
+  }));
 
 export const SectionHeader: React.FC = ({ children }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <Box className={classes.box}>

--- a/packages/amplify-material-ui/src/ui/toast.tsx
+++ b/packages/amplify-material-ui/src/ui/toast.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import clsx from 'clsx';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import InfoIcon from '@mui/icons-material/Info';
@@ -8,7 +7,7 @@ import WarningIcon from '@mui/icons-material/Warning';
 import { colors, IconButton, Snackbar, SnackbarOrigin, SnackbarContent } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 
 const variantIcon = {
   success: CheckCircleIcon,
@@ -17,7 +16,7 @@ const variantIcon = {
   info: InfoIcon,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   success: {
     backgroundColor: colors.green[600],
   },
@@ -67,18 +66,18 @@ export const Toast: React.FC<ToastProps> = (props) => {
     onClose,
   } = props;
 
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
 
   const Icon = variantIcon[variant];
 
   return (
     <Snackbar anchorOrigin={anchorOrigin} open={open} autoHideDuration={autoHideDuration} onClose={onClose}>
       <SnackbarContent
-        className={clsx(classes[variant], className)}
+        className={cx(classes[variant], className)}
         aria-describedby="client-snackbar"
         message={
           <span id="client-snackbar" className={classes.message}>
-            <Icon className={clsx(classes.icon, classes.iconVariant)} />
+            <Icon className={cx(classes.icon, classes.iconVariant)} />
             {content}
           </span>
         }

--- a/packages/amplify-material-ui/test/auth/__snapshots__/confirm-sign-in.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/confirm-sign-in.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`confirm-sign-in should be rendered correctly in the confirmSignIn authS
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-3 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-4 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-5 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -34,10 +34,10 @@ exports[`confirm-sign-in should be rendered correctly in the confirmSignIn authS
       </div>
       <form
         action="#"
-        class="makeStyles-form-1"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-6 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -85,10 +85,10 @@ exports[`confirm-sign-in should be rendered correctly in the confirmSignIn authS
           </div>
         </div>
         <div
-          class="makeStyles-box-7 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-2 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >

--- a/packages/amplify-material-ui/test/auth/__snapshots__/confirm-sign-up.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/confirm-sign-up.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`confirm-sign-up should be rendered correctly 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-3 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-4 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-5 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -34,10 +34,10 @@ exports[`confirm-sign-up should be rendered correctly 1`] = `
       </div>
       <form
         action="#"
-        class="makeStyles-form-1"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-6 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -85,10 +85,10 @@ exports[`confirm-sign-up should be rendered correctly 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-box-7 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-2 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >

--- a/packages/amplify-material-ui/test/auth/__snapshots__/forgot-password.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/forgot-password.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`forgot-password should be rendered correctly 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-3 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-4 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-5 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -34,10 +34,10 @@ exports[`forgot-password should be rendered correctly 1`] = `
       </div>
       <form
         action="#"
-        class="makeStyles-form-1"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-6 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -84,10 +84,10 @@ exports[`forgot-password should be rendered correctly 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-box-7 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-2 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >

--- a/packages/amplify-material-ui/test/auth/__snapshots__/loading.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/loading.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`loading should be rendered correctly 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-2 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <span
-        class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorSecondary makeStyles-progress-1 css-1szo49z-MuiCircularProgress-root"
+        class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorSecondary tss-ddnmuz-progress css-1szo49z-MuiCircularProgress-root"
         role="progressbar"
         style="width: 40px; height: 40px;"
       >

--- a/packages/amplify-material-ui/test/auth/__snapshots__/sign-in.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/sign-in.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`sign-in should be rendered correctly 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-3 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-4 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-5 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -34,11 +34,11 @@ exports[`sign-in should be rendered correctly 1`] = `
       </div>
       <form
         action="#"
-        class="makeStyles-form-1"
+        class="tss-16bg6wn-form"
         data-testid="signInForm"
       >
         <div
-          class="makeStyles-box-6 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -129,10 +129,10 @@ exports[`sign-in should be rendered correctly 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-box-7 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-2 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             data-testid="signInSubmit"
             tabindex="0"
             type="submit"

--- a/packages/amplify-material-ui/test/auth/__snapshots__/sign-up.test.tsx.snap
+++ b/packages/amplify-material-ui/test/auth/__snapshots__/sign-up.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`sign-up should allow custom initial values 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-24 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-25 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-26 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -34,10 +34,10 @@ exports[`sign-up should allow custom initial values 1`] = `
       </div>
       <form
         action="#"
-        class="makeStyles-form-22"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-27 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -170,10 +170,10 @@ exports[`sign-up should allow custom initial values 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-box-28 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-23 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >
@@ -210,13 +210,13 @@ exports[`sign-up should be rendered correctly 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-3 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-4 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-5 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -238,10 +238,10 @@ exports[`sign-up should be rendered correctly 1`] = `
       </div>
       <form
         action="#"
-        class="makeStyles-form-1"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-6 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -374,10 +374,10 @@ exports[`sign-up should be rendered correctly 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-box-7 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-2 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >
@@ -414,13 +414,13 @@ exports[`sign-up should render custom sign-up fields 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-10 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-11 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-12 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -442,10 +442,10 @@ exports[`sign-up should render custom sign-up fields 1`] = `
       </div>
       <form
         action="#"
-        class="makeStyles-form-8"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-13 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -621,10 +621,10 @@ exports[`sign-up should render custom sign-up fields 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-box-14 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-9 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >
@@ -661,13 +661,13 @@ exports[`sign-up should render custom sign-up fields in the correct order 1`] = 
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-17 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div
-        class="makeStyles-box-18 MuiBox-root css-0"
+        class="tss-10vlsjz-box MuiBox-root css-0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-19 css-2s90m6-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
         >
           <svg
             aria-hidden="true"
@@ -689,10 +689,10 @@ exports[`sign-up should render custom sign-up fields in the correct order 1`] = 
       </div>
       <form
         action="#"
-        class="makeStyles-form-15"
+        class="tss-16bg6wn-form"
       >
         <div
-          class="makeStyles-box-20 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
@@ -868,10 +868,10 @@ exports[`sign-up should render custom sign-up fields in the correct order 1`] = 
           </div>
         </div>
         <div
-          class="makeStyles-box-21 MuiBox-root css-0"
+          class="tss-zezy7h-box MuiBox-root css-0"
         >
           <button
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root makeStyles-submit-16 css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-fullWidth MuiButtonBase-root tss-apfx2m-submit css-1fu7jd5-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="submit"
           >

--- a/packages/amplify-material-ui/test/helpers/withTheme.tsx
+++ b/packages/amplify-material-ui/test/helpers/withTheme.tsx
@@ -1,5 +1,5 @@
 import { createTheme, ThemeProvider } from "@mui/material"
-import React  from "react"
+import * as React from "react"
 
 export const withTheme = (Component: React.ReactElement): JSX.Element => (
   <ThemeProvider theme={createTheme()}>

--- a/packages/amplify-material-ui/test/ui/__snapshots__/form-section.test.tsx.snap
+++ b/packages/amplify-material-ui/test/ui/__snapshots__/form-section.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`form-section should be rendered correctly 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthXs css-nzinn5-MuiContainer-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-1 css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 tss-fuibka-paper css-1ps6pg7-MuiPaper-root"
     >
       <div />
     </div>

--- a/packages/amplify-material-ui/test/ui/__snapshots__/section-body.test.tsx.snap
+++ b/packages/amplify-material-ui/test/ui/__snapshots__/section-body.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`section-body should be rendered correctly 1`] = `
 <DocumentFragment>
   <div
-    class="makeStyles-box-1 MuiBox-root css-0"
+    class="tss-zezy7h-box MuiBox-root css-0"
   >
     <div />
   </div>

--- a/packages/amplify-material-ui/test/ui/__snapshots__/section-footer.test.tsx.snap
+++ b/packages/amplify-material-ui/test/ui/__snapshots__/section-footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`section-footer should be rendered correctly 1`] = `
 <DocumentFragment>
   <div
-    class="makeStyles-box-1 MuiBox-root css-0"
+    class="tss-zezy7h-box MuiBox-root css-0"
   >
     <div />
   </div>

--- a/packages/amplify-material-ui/test/ui/__snapshots__/section-header.test.tsx.snap
+++ b/packages/amplify-material-ui/test/ui/__snapshots__/section-header.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`section-header should be rendered correctly 1`] = `
 <DocumentFragment>
   <div
-    class="makeStyles-box-1 MuiBox-root css-0"
+    class="tss-10vlsjz-box MuiBox-root css-0"
   >
     <div
-      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault makeStyles-avatar-2 css-2s90m6-MuiAvatar-root"
+      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault tss-wy3cmf-avatar css-2s90m6-MuiAvatar-root"
     >
       <svg
         aria-hidden="true"

--- a/packages/amplify-material-ui/test/ui/__snapshots__/toast.test.tsx.snap
+++ b/packages/amplify-material-ui/test/ui/__snapshots__/toast.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`loading should be rendered correctly (error) 1`] = `
   >
     <div
       aria-describedby="client-snackbar"
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root makeStyles-error-2 css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root tss-1d89wtr-error css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
       direction="down"
       role="alert"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
@@ -17,12 +17,12 @@ exports[`loading should be rendered correctly (error) 1`] = `
         class="MuiSnackbarContent-message css-1exqwzz-MuiSnackbarContent-message"
       >
         <span
-          class="makeStyles-message-7"
+          class="tss-13gvgh6-message"
           id="client-snackbar"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-5 makeStyles-iconVariant-6 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-ja2es6-icon-iconVariant css-i4bv87-MuiSvgIcon-root"
             data-testid="ErrorIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -45,7 +45,7 @@ exports[`loading should be rendered correctly (error) 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-5 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-sggep4-icon css-i4bv87-MuiSvgIcon-root"
             data-testid="CloseIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -72,7 +72,7 @@ exports[`loading should be rendered correctly (info) 1`] = `
   >
     <div
       aria-describedby="client-snackbar"
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root makeStyles-info-10 css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root tss-ynwxby-info css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
       direction="down"
       role="alert"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
@@ -81,12 +81,12 @@ exports[`loading should be rendered correctly (info) 1`] = `
         class="MuiSnackbarContent-message css-1exqwzz-MuiSnackbarContent-message"
       >
         <span
-          class="makeStyles-message-14"
+          class="tss-13gvgh6-message"
           id="client-snackbar"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-12 makeStyles-iconVariant-13 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-ja2es6-icon-iconVariant css-i4bv87-MuiSvgIcon-root"
             data-testid="InfoIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -109,7 +109,7 @@ exports[`loading should be rendered correctly (info) 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-12 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-sggep4-icon css-i4bv87-MuiSvgIcon-root"
             data-testid="CloseIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -136,7 +136,7 @@ exports[`loading should be rendered correctly (success) 1`] = `
   >
     <div
       aria-describedby="client-snackbar"
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root makeStyles-success-22 css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root tss-1heb5e3-success css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
       direction="down"
       role="alert"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
@@ -145,12 +145,12 @@ exports[`loading should be rendered correctly (success) 1`] = `
         class="MuiSnackbarContent-message css-1exqwzz-MuiSnackbarContent-message"
       >
         <span
-          class="makeStyles-message-28"
+          class="tss-13gvgh6-message"
           id="client-snackbar"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-26 makeStyles-iconVariant-27 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-ja2es6-icon-iconVariant css-i4bv87-MuiSvgIcon-root"
             data-testid="CheckCircleIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -173,7 +173,7 @@ exports[`loading should be rendered correctly (success) 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-26 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-sggep4-icon css-i4bv87-MuiSvgIcon-root"
             data-testid="CloseIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -200,7 +200,7 @@ exports[`loading should be rendered correctly (warning) 1`] = `
   >
     <div
       aria-describedby="client-snackbar"
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root makeStyles-warning-18 css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root tss-1eqoytq-warning css-1eqdgzv-MuiPaper-root-MuiSnackbarContent-root"
       direction="down"
       role="alert"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
@@ -209,12 +209,12 @@ exports[`loading should be rendered correctly (warning) 1`] = `
         class="MuiSnackbarContent-message css-1exqwzz-MuiSnackbarContent-message"
       >
         <span
-          class="makeStyles-message-21"
+          class="tss-13gvgh6-message"
           id="client-snackbar"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-19 makeStyles-iconVariant-20 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-ja2es6-icon-iconVariant css-i4bv87-MuiSvgIcon-root"
             data-testid="WarningIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -237,7 +237,7 @@ exports[`loading should be rendered correctly (warning) 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-icon-19 css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium tss-sggep4-icon css-i4bv87-MuiSvgIcon-root"
             data-testid="CloseIcon"
             focusable="false"
             viewBox="0 0 24 24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,6 +3089,17 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
+"@emotion/cache@*":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
+  integrity sha512-0dgkI/JKlCXa+lEXviaMtGBL0ynpx4osh7rjOXE71q9bIF8G+XhJgvi+wDu0B0IdCVx37BffiwXlN9I3UuzFvg==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "4.0.13"
+
 "@emotion/cache@^11.7.1":
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
@@ -3130,6 +3141,17 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/serialize@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.4.tgz#ff31fd11bb07999611199c2229e152faadc21a3c"
+  integrity sha512-1JHamSpH8PIfFwAMryO2bNka+y8+KA5yga5Ocf2d7ZEiJjb7xlLW7aknBGZqJLajuLOvJ+72vN+IBSwPlXD1Pg==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
 "@emotion/serialize@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
@@ -3146,6 +3168,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
 
+"@emotion/sheet@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.1.tgz#015756e2a9a3c7c5f11d8ec22966a8dbfbfac787"
+  integrity sha512-J3YPccVRMiTZxYAY0IOq3kd+hUP8idY8Kz6B/Cyo+JuXq52Ek+zbPbSQUrVQp95aJ+lsAW7DPL1P2Z+U1jGkKA==
+
 "@emotion/styled@^11.6.0":
   version "11.6.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.6.0.tgz#9230d1a7bcb2ebf83c6a579f4c80e0664132d81d"
@@ -3161,6 +3188,11 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
+  integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
 
 "@emotion/utils@^1.0.0":
   version "1.0.0"
@@ -17080,6 +17112,15 @@ tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tss-react@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-3.7.0.tgz#664b4259c36800eb5285a583f6d8c1d5d1d1a30f"
+  integrity sha512-thvJWR+sr3ZGMcV/Ryo1F5RzjXd1gMTzYV/ckfUEBhu701uTYE3KyL9DNxv827uRFPFSLYG7bKefuc7kmYMB9Q==
+  dependencies:
+    "@emotion/cache" "*"
+    "@emotion/serialize" "*"
+    "@emotion/utils" "*"
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Existing jss styling in this library doesn't work with SSR, and specifically with Next.js. So **now it works!**

Here are the changes I made:

- Ran an official @mui codemod to replace jss with tss-react.
- The generated fixes had syntax errors so I fixed them by hand.
- Updated the test snapshots, because tss-react generates different class names than jss' makeStyles.
- Tested this library with my Next.js project with SSR.
- Updated the Readme file to ask users to install the necessary peer dependencies and included a section "Enable SSR".


Side note: I think we should include styles in test snapshots. Because I wasn't sure if my changes broke styling as I only saw different class-names. I found how this is done for styled-components with jest-styled-components. There must be a similar solution for tss-react and emotion that it uses. 